### PR TITLE
feat: add projects listing with donation progress

### DIFF
--- a/power-matrix-frontend/src/App.tsx
+++ b/power-matrix-frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from "./pages/Dashboard";
 import MarketPlace from "./pages/MarketPlace";
 import MarketCap from "./pages/MarketCap";
 import Login from "./pages/Login";
+import Projects from "./pages/Projects";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 const queryClient = new QueryClient();
 
@@ -25,6 +26,7 @@ const App = () => (
           <Route path="*" element={<NotFound />} />
           <Route path="/dashboard" element={<Dashboard/>} />
           <Route path="/marketplace" element={<MarketPlace/>} />
+          <Route path="/projects" element={<Projects/>} />
           <Route path='/marketcap' element={<MarketCap/>} />
           <Route path='/login' element={<Login/>} />
         </Routes>

--- a/power-matrix-frontend/src/components/Header.tsx
+++ b/power-matrix-frontend/src/components/Header.tsx
@@ -35,7 +35,7 @@ const Header = () => {
         {/* Navigation */}
         <nav className="hidden md:flex items-center gap-8">
           <a href="/dashboard" className="text-foreground/80 hover:text-primary transition-colors font-medium">Dashboard</a>
-          <a href="#" className="text-foreground/80 hover:text-primary transition-colors font-medium">Projects</a>
+          <a href="/projects" className="text-foreground/80 hover:text-primary transition-colors font-medium">Projects</a>
           <a href="/marketplace" className="text-foreground/80 hover:text-primary transition-colors font-medium">Marketplace</a>
           <a href="#" className="text-foreground/80 hover:text-primary transition-colors font-medium">Community</a>
         </nav>

--- a/power-matrix-frontend/src/pages/MarketPlace.tsx
+++ b/power-matrix-frontend/src/pages/MarketPlace.tsx
@@ -8,6 +8,14 @@ import {
   buyListing,
   ensureApprovalForAll,
 } from "@/blockchain/market";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
 
 type Row = { id: number; seller: string; tokenId: number; amount: number; priceEth: string };
 
@@ -27,6 +35,39 @@ const MarketPlace: React.FC = () => {
   // sell form (we use "price per credit (ETH)" and compute total for the bundle)
   const [sellQty, setSellQty] = useState<string>("");
   const [sellUnitEth, setSellUnitEth] = useState<string>("");
+
+  // demo datasets for exchange-style view
+  const priceHistory = [
+    { time: "09:00", price: 1.12 },
+    { time: "10:00", price: 1.18 },
+    { time: "11:00", price: 1.15 },
+    { time: "12:00", price: 1.22 },
+    { time: "13:00", price: 1.2 },
+    { time: "14:00", price: 1.27 },
+  ];
+  const orderBookDemo = {
+    bids: [
+      { price: 1.24, amount: 50 },
+      { price: 1.23, amount: 40 },
+      { price: 1.22, amount: 60 },
+      { price: 1.21, amount: 70 },
+      { price: 1.2, amount: 30 },
+    ],
+    asks: [
+      { price: 1.26, amount: 50 },
+      { price: 1.27, amount: 35 },
+      { price: 1.28, amount: 65 },
+      { price: 1.29, amount: 45 },
+      { price: 1.3, amount: 55 },
+    ],
+  };
+  const tradeHistory = [
+    { time: "13:55:10", price: 1.26, amount: 5, side: "buy" as const },
+    { time: "13:54:55", price: 1.25, amount: 3, side: "sell" as const },
+    { time: "13:54:40", price: 1.25, amount: 2, side: "buy" as const },
+    { time: "13:54:20", price: 1.27, amount: 1, side: "sell" as const },
+    { time: "13:54:05", price: 1.26, amount: 4, side: "buy" as const },
+  ];
 
   const bestAsk = useMemo(() => {
     if (!rows.length) return "--";
@@ -108,7 +149,97 @@ const MarketPlace: React.FC = () => {
     <>
       <Header />
       <div className="bg-[#10182A] min-h-screen text-white font-inter p-8 mt-16">
-        <div className="max-w-5xl mx-auto">
+        <div className="max-w-7xl mx-auto">
+          {/* exchange style demo section */}
+          <div className="grid md:grid-cols-3 gap-8 mb-10">
+            {/* chart */}
+            <Card className="bg-[#181F36] rounded-2xl shadow-md border-0 md:col-span-2">
+              <CardHeader>
+                <CardTitle className="text-xl">Price Chart</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={priceHistory}>
+                      <XAxis dataKey="time" stroke="#B0B8D1" />
+                      <YAxis stroke="#B0B8D1" domain={[1.1, 1.3]} />
+                      <Tooltip
+                        contentStyle={{ background: "#232B45", border: "none" }}
+                        labelStyle={{ color: "#fff" }}
+                      />
+                      <Line type="monotone" dataKey="price" stroke="#0DF6A9" strokeWidth={2} dot={false} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* order book and trades */}
+            <div className="space-y-8">
+              <Card className="bg-[#181F36] rounded-2xl shadow-md border-0">
+                <CardHeader>
+                  <CardTitle className="text-xl">Order Book</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-4 text-xs">
+                    {/* bids */}
+                    <table className="w-full text-left">
+                      <tbody>
+                        {orderBookDemo.bids.map((o, i) => (
+                          <tr key={`bid-${i}`} className="text-[#0DF6A9]">
+                            <td>{o.price.toFixed(4)}</td>
+                            <td>{o.amount}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {/* asks */}
+                    <table className="w-full text-right">
+                      <tbody>
+                        {orderBookDemo.asks.map((o, i) => (
+                          <tr key={`ask-${i}`} className="text-[#FF5A5F]">
+                            <td>{o.price.toFixed(4)}</td>
+                            <td>{o.amount}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card className="bg-[#181F36] rounded-2xl shadow-md border-0">
+                <CardHeader>
+                  <CardTitle className="text-xl">Recent Trades</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="text-[#B0B8D1]">
+                        <th className="text-left">Time</th>
+                        <th className="text-right">Price</th>
+                        <th className="text-right">Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tradeHistory.map((t, i) => (
+                        <tr key={`trade-${i}`} className="border-t border-[#232B45]">
+                          <td>{t.time}</td>
+                          <td
+                            className={`text-right ${
+                              t.side === "buy" ? "text-[#0DF6A9]" : "text-[#FF5A5F]"
+                            }`}
+                          >
+                            {t.price.toFixed(4)}
+                          </td>
+                          <td className="text-right">{t.amount}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
           {/* tabs */}
           <div className="flex items-center gap-4 mb-2">
             <button

--- a/power-matrix-frontend/src/pages/Projects.tsx
+++ b/power-matrix-frontend/src/pages/Projects.tsx
@@ -1,0 +1,144 @@
+import Header from "@/components/Header";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+
+interface Project {
+  id: number;
+  title: string;
+  description: string;
+  image: string;
+  goal: number; // PMGT needed
+  raised: number; // PMGT received
+}
+
+const projects: Project[] = [
+  {
+    id: 1,
+    title: "Tree Plantation Drive",
+    description: "Plant 10,000 trees across urban areas to combat pollution.",
+    image: "https://images.unsplash.com/photo-1506765515384-028b60a970df?auto=format&fit=crop&w=800&q=60",
+    goal: 5000,
+    raised: 3200,
+  },
+  {
+    id: 2,
+    title: "Solar Village Initiative",
+    description: "Install solar panels in remote villages for clean energy.",
+    image: "https://images.unsplash.com/photo-1509395176047-4a66953fd231?auto=format&fit=crop&w=800&q=60",
+    goal: 8000,
+    raised: 4200,
+  },
+  {
+    id: 3,
+    title: "Clean Water Project",
+    description: "Provide sustainable water filtration systems for rural communities.",
+    image: "https://images.unsplash.com/photo-1508873699372-7ae5aa79f81d?auto=format&fit=crop&w=800&q=60",
+    goal: 6000,
+    raised: 2500,
+  },
+  {
+    id: 4,
+    title: "Community Recycling Program",
+    description: "Set up recycling centers and awareness programs in cities.",
+    image: "https://images.unsplash.com/photo-1494599948593-3dafe8338d71?auto=format&fit=crop&w=800&q=60",
+    goal: 4000,
+    raised: 1500,
+  },
+  {
+    id: 5,
+    title: "Wildlife Conservation",
+    description: "Protect endangered species through habitat restoration.",
+    image: "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=800&q=60",
+    goal: 7000,
+    raised: 4600,
+  },
+  {
+    id: 6,
+    title: "Urban Community Gardens",
+    description: "Create community gardens to promote local food production.",
+    image: "https://images.unsplash.com/photo-1524594154908-edd3bb1e4b6f?auto=format&fit=crop&w=800&q=60",
+    goal: 3000,
+    raised: 1200,
+  },
+  {
+    id: 7,
+    title: "Wind Energy for Schools",
+    description: "Install small wind turbines to power rural schools.",
+    image: "https://images.unsplash.com/photo-1509395062183-67c5ad6f3d02?auto=format&fit=crop&w=800&q=60",
+    goal: 6500,
+    raised: 2800,
+  },
+  {
+    id: 8,
+    title: "Eco-Friendly Housing",
+    description: "Build energy-efficient homes for low-income families.",
+    image: "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?auto=format&fit=crop&w=800&q=60",
+    goal: 9000,
+    raised: 5100,
+  },
+  {
+    id: 9,
+    title: "Ocean Cleanup Mission",
+    description: "Deploy cleanup devices to remove plastic from oceans.",
+    image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=60",
+    goal: 10000,
+    raised: 6700,
+  },
+  {
+    id: 10,
+    title: "Green Transport Program",
+    description: "Introduce electric bicycles for last-mile connectivity in cities.",
+    image: "https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=800&q=60",
+    goal: 5500,
+    raised: 2000,
+  },
+];
+
+const Projects = () => {
+  return (
+    <>
+      <Header />
+      <div className="bg-[#10182A] min-h-screen text-white font-inter p-8 mt-16">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-3xl font-bold mb-8 text-center">Support Social Impact Projects</h1>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            {projects.map((proj) => {
+              const pct = (proj.raised / proj.goal) * 100;
+              return (
+                <Card key={proj.id} className="bg-[#181F36] rounded-2xl shadow-md border-0 overflow-hidden">
+                  <img src={proj.image} alt={proj.title} className="w-full h-40 object-cover" />
+                  <CardHeader>
+                    <CardTitle className="text-xl">{proj.title}</CardTitle>
+                    <CardDescription className="text-[#B0B8D1]">
+                      {proj.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="text-sm mb-2 text-[#B0B8D1]">
+                      Raised <span className="text-[#FFD600] font-semibold">{proj.raised}</span> /{" "}
+                      <span className="text-[#0DF6A9] font-semibold">{proj.goal}</span> PMGT
+                    </div>
+                    <Progress value={pct} />
+                  </CardContent>
+                  <CardFooter className="flex items-center justify-between">
+                    <Button className="bg-[#0DF6A9] text-[#10182A] hover:bg-[#0DF6A9]/90">
+                      Donate
+                    </Button>
+                    <span className="text-xs text-[#B0B8D1]">20% PMGT bonus</span>
+                  </CardFooter>
+                </Card>
+              );
+            })}
+          </div>
+          <p className="text-center text-xs text-[#B0B8D1] mt-10">
+            Donations are credited to project listers after verification. Donors receive 20% of their contribution back in PMGT.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Projects;
+


### PR DESCRIPTION
## Summary
- add Projects page with sample social-cause campaigns and progress bars
- wire up /projects route and navigation link

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any / no-empty-object-type)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bac635ac70832f80bf1e098befad31